### PR TITLE
Fixed viewer for containers and removed deprecation warning.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
   - conda update -q conda
   - conda config --set anaconda_upload no
 
-  - conda install python=$TRAVIS_PYTHON_VERSION output_viewer pyyaml dask distributed six nose -c conda-forge -c uvcdat -y
+  - conda install python=$TRAVIS_PYTHON_VERSION output_viewer pyyaml dask distributed six nose -c conda-forge -c cdat -y
 
   - find cdp/test/test_*.py -exec python {} \;
 

--- a/cdp/__init__.py
+++ b/cdp/__init__.py
@@ -3,10 +3,8 @@ from __future__ import absolute_import
 from . import cdp_metric
 from . import cdp_parameter
 from . import cdp_provenance
-from . import cdp_viewer
 from . import cdp_io
 from . import cdp_parser
 from . import cdp_run
 
 __version__ = 'v1.4.0'
-

--- a/cdp/cdp_run.py
+++ b/cdp/cdp_run.py
@@ -1,22 +1,25 @@
 from __future__ import print_function
 
 import dask.bag
-import dask.multiprocessing
 from dask.distributed import Client
 
 
 def serial(func, parameters):
-    """Run the function with the parameters serially."""
+    """
+    Run the function with the parameters serially.
+    """
     results = []
     for p in parameters:
         results.append(func(p))
     return results
 
 def multiprocess(func, parameters, num_workers=None):
-    """Run the function with the parameters in parallel using multiprocessing."""
+    """
+    Run the function with the parameters in parallel using multiprocessing.
+    """
     bag = dask.bag.from_sequence(parameters)
 
-    with dask.set_options(get=dask.multiprocessing.get):
+    with dask.config.set(scheduler='processes'):
         if num_workers:
             results = bag.map(func).compute(num_workers=num_workers)
         elif hasattr(parameters[0], 'num_workers'):
@@ -28,7 +31,9 @@ def multiprocess(func, parameters, num_workers=None):
         return results
 
 def distribute(func, parameters, scheduler_addr=None):
-    """Run the function with the parameters in parallel distributedly."""
+    """
+    Run the function with the parameters in parallel distributedly.
+    """
     try:
         if scheduler_addr:
             addr = scheduler_addr

--- a/cdp/cdp_viewer.py
+++ b/cdp/cdp_viewer.py
@@ -90,7 +90,6 @@ class OutputViewer(object):
                 default_mask=default_mask)
 
         if os.path.exists(os.path.join(self.path, "index.html")):
-            print("Viewer HTML generated at {path}/index.html".format(path=self.path))
             if prompt_user:
                 user_prompt = "Would you like to open in a browser? y/[n]: "
                 should_open = input(user_prompt)


### PR DESCRIPTION
* No more deprecation warning from Dask.
* Removed abs path for the viewer, since running in the container prints the incorrect information.
* `import cdp` no longer needs the `output_viewer` installed:
    ```
    >>> import cdp
    >>> import cdp.cdp_viewer
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/Users/shaheen2/anaconda2/envs/dask/lib/python3.6/site-packages/cdp-1.4.0-py3.6.egg/cdp/cdp_viewer.py", line 5, in <module>
        from output_viewer.build import build_viewer
    ModuleNotFoundError: No module named 'output_viewer'
```