### PR TITLE
Alias

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ aliases:
        cd conda-recipes
        export PKG_NAME=cdp
        export USER=cdat
-       export VERSION=1.3.3
+       export VERSION=1.4.1
        export LABEL=nightly
        export DATE=`date +%Y.%m.%d.%H.%M`
        ln -s ../conda cdp

--- a/cdp/cdp_provenance.py
+++ b/cdp/cdp_provenance.py
@@ -112,18 +112,9 @@ def save_parameter_as_py(param, file_name, parser):
         else:
             line = '{} = {}'
         py_contents.append(line.format(var_name, var_value))
-
-    '''
-    for l in py_contents:
-        if not l.endswith('\n'):
-            l += '\n'
-        print(l, end='')
-    '''
     
     with open(file_name, 'w') as f:
         for l in py_contents:
             if not l.endswith('\n'):
                 l += '\n'
             f.write(l)
-    
-    # return py_contents

--- a/cdp/test/json_files/test_aliases.json
+++ b/cdp/test/json_files/test_aliases.json
@@ -1,0 +1,9 @@
+{
+	"--arg": {
+		"aliases": [
+			"--another_arg"
+		],
+		"dest": "arg",
+		"help": "A set of sample arguments"
+	}
+}

--- a/cdp/test/parameter_files/test_aliases.py
+++ b/cdp/test/parameter_files/test_aliases.py
@@ -1,0 +1,1 @@
+arg = 'THIS IS THE ARG'

--- a/cdp/test/test_cdp_parser.py
+++ b/cdp/test/test_cdp_parser.py
@@ -711,6 +711,18 @@ class TestCDPParser(unittest.TestCase):
         self.assertTrue(hasattr(params[0], 'vars'))
         self.assertFalse(hasattr(params[0], 'some_other_param'))
 
+    def test_aliases(self):
+        pth = os.path.join(os.path.dirname(__file__), "json_files")
+        parser = cdp.cdp_parser.CDPParser(None, [os.path.join(pth, "DefArgsCIA.json"),
+                                            os.path.join(pth, "test_aliases.json")])
+        parser.use("parameters")
+        parser.use("diags")
+        parser.use("arg")
+
+        parser.add_args_and_values(['-p', self.prefix + 'test_aliases.py'])
+
+        params = parser.get_parameter()
+        self.assertEqual(params.arg, params.another_arg)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* Adds the ability for the aliases defined in the `argparse.add_argument()` function to be used as attributes to the Parameter object.