### PR TITLE
Update cdp_parser.py

### DIFF
--- a/cdp/cdp_parser.py
+++ b/cdp/cdp_parser.py
@@ -107,7 +107,7 @@ class CDPParser(argparse.ArgumentParser):
         """
         self._parse_arguments()
         
-        if not self.__args_namespace.parameters:
+        if not self.__args_namespace:
             return None
 
         parameter = self.__parameter_cls()
@@ -115,9 +115,9 @@ class CDPParser(argparse.ArgumentParser):
         # Remove all of the variables.
         parameter.__dict__.clear()
 
-        # if self.__args_namespace.parameters is not None:
+        # if self.__args_namespace is not None:
         parameter.load_parameter_from_py(
-            self.__args_namespace.parameters)
+            self.__args_namespace)
 
         if check_values:
             parameter.check_values()


### PR DESCRIPTION
I was recently working with the arm_diags package that uses this library.  I am currently trying to update the arm_diags package from Python 2 to Python 3 respectfully.  With the old Python 2 version, we were using cdp V1.0.3  With the updates moving toward Python 3, we are trying to utilize the newest version of cdp v1.6.0.  With this, I noticed a potential issue in the code when I tried to use this library in my package.  Particularly,  on lines 110-120 there is use of __args_namespace.parameter, but this is never used again in the code.  It looks like there is not a method that initializes __args_namespace.parameters. Perhaps this was meant to be __args_namespace?  If this is the case, I forked this project and made the changes accordingly.  If possible I would like to hear your thoughts. Thank you. 